### PR TITLE
Adding control systems count as metadata. closes #1

### DIFF
--- a/R/cchart.R
+++ b/R/cchart.R
@@ -150,10 +150,14 @@ ccpoints <- function(data, dates, values, points.vs.avg = 6, points.vs.sd = 4) {
       count.n <- 0
     }
   }
+
+  #Function Return
+
   l<-list()
   l[["data"]] <- data[, which(names(data) %in% c(dates, values, "data.mean", "data.ll", "data.ul"))]
   l[["dates.name"]] <- dates
   l[["values.name"]] <- values
+  l[["systems_count"]] <- length(unique(data$data.mean))
   class(l) <- c("ccpoints")
   return(l)
 }


### PR DESCRIPTION
An extra metadata field has been added to the ccpoints object as a list entry named "systems_count"