### PR TITLE
Feature-metadata

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: ccharter
 Type: Package
 Title: Control Charts made easy
-Version: 0.1.0
+Version: 0.1.1
 Authors@R: person("Juan", "Brandao", email = "jbf8dof@outlook.com",
   role = c("aut", "cre"))
 URL: https://github.com/jbaxx/ccharter

--- a/R/cchart.R
+++ b/R/cchart.R
@@ -200,11 +200,26 @@ ccpoints <- function(data, dates, values, points.vs.avg = 6, points.vs.sd = 4) {
   #Function Return
 
   l<-list()
-  l[["data"]] <- data[, which(names(data) %in% c(dates, values, "data.mean", "data.ll", "data.ul"))]
+  l[["data"]] <- data#[, which(names(data) %in% c(dates, values, "data.mean", "data.ll", "data.ul"))]
   l[["dates.name"]] <- dates
   l[["values.name"]] <- values
   l[["systems_count"]] <- length(unique(data$data.mean))
   l[["missing_values"]] <- missing_values
+
+  # Subset only last system
+  last <- data[which(data$data.mean == unique(data$data.mean)[length(unique(data$data.mean))]), ]
+  l[["date_last_break"]] <- last[1, dates]
+  l[["weeks_since_last_break"]] <- floor(difftime(Sys.Date(), last[1, dates], units = "weeks"))
+
+  next_break <- c("Next system expected to break positive", "Next system expected to break negative")
+  l[["next_break"]] <- next_break[as.numeric(count.p < count.n) + 1]
+
+  next_break_mean <- c(points.vs.avg - count.p, points.vs.avg - count.n)
+  next_break_sd <- c(points.vs.sd - count.sd.p, points.vs.sd - count.sd.n)
+
+  l[["next_break_values"]] <- c("Continous points vs mean: " = next_break_mean[as.numeric(count.p < count.n) + 1],
+                                "Continuous points vs 2 SD: " = next_break_sd[as.numeric(count.sd.p < count.sd.n) + 1])
+
 
   class(l) <- c("ccpoints")
   return(l)

--- a/R/cchart.R
+++ b/R/cchart.R
@@ -81,7 +81,7 @@ ccpoints <- function(data, dates, values, points.vs.avg = 6, points.vs.sd = 4) {
 
   #NUMERIC DATA PREPARATION
   #Remove commas if present
-  data[, values] <- gsub(",", "", data[, values])
+  data[, values] <- as.numeric(gsub(",", "", data[, values]))
 
   #Data handling for values data points, specially for factors coercion
   if (!is.numeric(data[, values])){


### PR DESCRIPTION
Adds as list items within the ccpoints class the following metadata:
* Date of last break (item name: $date_last_break)
* Weeks since last break (item name: $weeks_since_last_break)
* Expectation of next system to break positive or negative (item name: $next_break)
* Points remaining (above/below) to break with mean and with SD (item name: $next_break_values)

closes #6 , closes #10 