### PR TITLE
Feature dataset length

### DIFF
--- a/R/cchart.R
+++ b/R/cchart.R
@@ -52,6 +52,14 @@
 ccpoints <- function(data, dates, values, points.vs.avg = 6, points.vs.sd = 4,
                      date.type = TRUE, already.ordered = FALSE) {
 
+  if(nrow(data) <= 6){
+    stop("Not enough data points, 6 or less supplied")
+  }
+
+  if(nrow(data) > 6 & nrow(data) <= 12){
+    warning("Between 6 and 12 data points supplied, function executed but may not return system breaks")
+  }
+
   ######
   #1. Data Preparation Begins
   ######


### PR DESCRIPTION
Since the control chart rule applied is to establish the first 6 points as the control group, by default will fail with data sets with less than 6 points. @edgarnp
* Added a clear error + message if 6 or less points are provided. This error may be caught.
* Added a warning + message if between 7 and 12 points provided, since the function will execute but may not return a system break.
closes #12 